### PR TITLE
Fixed the shell script errors

### DIFF
--- a/scripts/create.sh
+++ b/scripts/create.sh
@@ -97,7 +97,7 @@ JAVA_CMD=(bazel run
   --define "repo=${REPO}"
   "--host_java_toolchain="@bazel_tools//tools/jdk:toolchain_hostjdk8
   "--java_toolchain="@bazel_tools//tools/jdk:toolchain_hostjdk8
-  #--host_java_toolchain='@bazel_tools//tools/jdk:toolchain_hostjdk8'
+  #--host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
   #--java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
   //java-spring-boot:k8s.apply)
 

--- a/scripts/create.sh
+++ b/scripts/create.sh
@@ -95,8 +95,10 @@ fi
 JAVA_CMD=(bazel run
   --define "cluster=${CONTEXT}"
   --define "repo=${REPO}"
-  --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8 
-  --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+  "--host_java_toolchain="@bazel_tools//tools/jdk:toolchain_hostjdk8
+  "--java_toolchain="@bazel_tools//tools/jdk:toolchain_hostjdk8
+  #--host_java_toolchain='@bazel_tools//tools/jdk:toolchain_hostjdk8'
+  #--java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
   //java-spring-boot:k8s.apply)
 
 if [[ $RBE != false ]]; then

--- a/scripts/teardown.sh
+++ b/scripts/teardown.sh
@@ -38,7 +38,7 @@ rm -f "$ROOT/terraform/terraform.tfstate.backup"
 # remove kubectl context & cluster from config
 CONTEXT=$(kubectl config get-contexts -o=name | grep "$(gcloud config get-value project).*gke-bazel-tutorial")
 
-if [[ ! -z $CONTEXT ]]; then
+if [[  -n $CONTEXT ]]; then
   kubectl config delete-context "$CONTEXT"
   kubectl config delete-cluster "$CONTEXT"
   kubectl config unset "users.$CONTEXT"

--- a/test/make.sh
+++ b/test/make.sh
@@ -81,8 +81,8 @@ function check_shell() {
 function check_java() {
   echo "Formatting Java"
   find . -name "*.java" -not -path "./planter/*" -exec sh -c \
-    'java -jar ~/Downloads/checkstyle-8.15-all.jar -c /google_checks.xml "$1"'\
-		-x {} \;
+    ""java -jar ~/Downloads/checkstyle-8.15-all.jar -c /google_checks.xml "$1"""\
+	-x {} \;
 }
 
 # This function runs the `yarn buildifier` command.


### PR DESCRIPTION
Fixed the following shell script errors:

In ./scripts/teardown.sh line 41:
if [[ ! -z $CONTEXT ]]; then
      ^-- SC2236: Use -n instead of ! -z.

For more information:
  https://www.shellcheck.net/wiki/SC2236 -- Use -n instead of ! -z.

In ./scripts/create.sh line 98:
  --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8 
  ^--------------------^ SC2191: The = here is literal. To assign by index, use ( [index]=value ) with no spaces. To keep as literal, quote it.


In ./scripts/create.sh line 99:
  --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
  ^---------------^ SC2191: The = here is literal. To assign by index, use ( [index]=value ) with no spaces. To keep as literal, quote it.
